### PR TITLE
Fixed crash when timerfd_create failed

### DIFF
--- a/gps/utils/LocTimer.cpp
+++ b/gps/utils/LocTimer.cpp
@@ -183,7 +183,7 @@ class LocTimerDelegate : public LocRankable {
         : mClient(NULL), mLock(NULL), mFutureTime(delay), mContainer(NULL) {}
     inline ~LocTimerDelegate() { if (mLock) { mLock->drop(); mLock = NULL; } }
 public:
-    LocTimerDelegate(LocTimer& client, struct timespec& futureTime, bool wakeOnExpire);
+    LocTimerDelegate(LocTimer& client, struct timespec& futureTime, LocTimerContainer* container);
     void destroyLocked();
     // LocRankable virtual method
     virtual int ranks(LocRankable& rankable);
@@ -472,11 +472,13 @@ bool LocTimerPollTask::run() {
 /***************************LocTimerDelegate methods***************************/
 
 inline
-LocTimerDelegate::LocTimerDelegate(LocTimer& client, struct timespec& futureTime, bool wakeOnExpire)
+LocTimerDelegate::LocTimerDelegate(LocTimer& client,
+                                   struct timespec& futureTime,
+                                   LocTimerContainer* container)
     : mClient(&client),
       mLock(mClient->mLock->share()),
       mFutureTime(futureTime),
-      mContainer(LocTimerContainer::get(wakeOnExpire)) {
+      mContainer(container) {
     // adding the timer into the container
     mContainer->add(*this);
 }
@@ -556,8 +558,13 @@ bool LocTimer::start(unsigned int timeOutInMs, bool wakeOnExpire) {
             futureTime.tv_sec += futureTime.tv_nsec / 1000000000;
             futureTime.tv_nsec %= 1000000000;
         }
-        mTimer = new LocTimerDelegate(*this, futureTime, wakeOnExpire);
-        // if mTimer is non 0, success should be 0; or vice versa
+
+        LocTimerContainer* container;
+        container = LocTimerContainer::get(wakeOnExpire);
+        if (NULL != container) {
+            mTimer = new LocTimerDelegate(*this, futureTime, container);
+            // if mTimer is non 0, success should be 0; or vice versa
+        }
         success = (NULL != mTimer);
     }
     mLock->unlock();


### PR DESCRIPTION
Implemented graceful fallback when
timerfd_create is failing for
CLOCK_BOOTTIME_ALARM

Change-Id: I6561be840f37a985104a2766fc4b521d237da3b2
CRs-fixed: 2051787