### PR TITLE
Clear the GNSS Sv used list data when position fix fails

### DIFF
--- a/gps/loc_api/libloc_api_50001/loc_eng.cpp
+++ b/gps/loc_api/libloc_api_50001/loc_eng.cpp
@@ -781,6 +781,7 @@ void LocEngReportPosition::proc() const {
     if (locEng->mute_session_state != LOC_MUTE_SESS_IN_SESSION) {
         bool reported = false;
         if (locEng->location_cb != NULL) {
+            adapter->clearGnssSvUsedListData();
             if (LOC_SESS_FAILURE == mStatus) {
                 // in case we want to handle the failure case
                 locEng->location_cb(NULL, NULL);


### PR DESCRIPTION
Clear the GNSS Sv used list data when position fix fails or
signal is lost so that it does not report stale SV used list
for SV report function.

Change-Id: Ia4bca6df98fd66bcccf65a730b3ca2f5dafbde63
CRs-Fixed: 1114610